### PR TITLE
Add Jupyter notebook stripping for VCS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.ipynb filter=nbstripout
+
+*.ipynb diff=ipynb

--- a/pip_only_requirements.txt
+++ b/pip_only_requirements.txt
@@ -1,2 +1,3 @@
 # NOTE: Dependencies should only be added to this file if they are not available in Anaconda!
 webrtcvad==2.0.10
+nbstripout==0.3.3

--- a/training/Gender Classification Model in Keras.ipynb
+++ b/training/Gender Classification Model in Keras.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -55,9 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%run -i \"../audio_preprocessing/generate_features.py\" -f mfcc -s 1 --local_download_dir \"../.audio\" --output_dir \"../.outputs\" "
@@ -65,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,18 +194,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(30, 799, 13)\n",
-      "(30, 2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "[print(a.shape) for a in [encoder_input_data, gender_data]]\n",
     "\n",
@@ -240,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,67 +234,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train on 24 samples, validate on 6 samples\n",
-      "Epoch 1/25\n",
-      "24/24 [==============================] - 6s 264ms/step - loss: 0.6881 - acc: 0.6667 - val_loss: 0.6693 - val_acc: 0.8333\n",
-      "Epoch 2/25\n",
-      "24/24 [==============================] - 4s 157ms/step - loss: 0.6744 - acc: 0.6667 - val_loss: 0.6470 - val_acc: 0.8333\n",
-      "Epoch 3/25\n",
-      "24/24 [==============================] - 4s 150ms/step - loss: 0.6380 - acc: 0.6667 - val_loss: 0.6284 - val_acc: 0.8333\n",
-      "Epoch 4/25\n",
-      "24/24 [==============================] - 4s 155ms/step - loss: 0.6239 - acc: 0.6667 - val_loss: 0.6065 - val_acc: 0.8333\n",
-      "Epoch 5/25\n",
-      "24/24 [==============================] - 4s 149ms/step - loss: 0.6050 - acc: 0.6667 - val_loss: 0.5845 - val_acc: 0.8333\n",
-      "Epoch 6/25\n",
-      "24/24 [==============================] - 4s 158ms/step - loss: 0.6268 - acc: 0.6667 - val_loss: 0.5591 - val_acc: 0.8333\n",
-      "Epoch 7/25\n",
-      "24/24 [==============================] - 4s 178ms/step - loss: 0.5982 - acc: 0.6667 - val_loss: 0.5336 - val_acc: 0.8333\n",
-      "Epoch 8/25\n",
-      "24/24 [==============================] - 4s 174ms/step - loss: 0.6209 - acc: 0.6667 - val_loss: 0.5061 - val_acc: 0.8333\n",
-      "Epoch 9/25\n",
-      "24/24 [==============================] - 4s 155ms/step - loss: 0.6053 - acc: 0.6667 - val_loss: 0.5075 - val_acc: 0.8333\n",
-      "Epoch 10/25\n",
-      "24/24 [==============================] - 4s 149ms/step - loss: 0.6032 - acc: 0.6667 - val_loss: 0.5138 - val_acc: 0.8333\n",
-      "Epoch 11/25\n",
-      "24/24 [==============================] - 4s 149ms/step - loss: 0.6399 - acc: 0.6667 - val_loss: 0.5457 - val_acc: 0.8333\n",
-      "Epoch 12/25\n",
-      "24/24 [==============================] - 4s 147ms/step - loss: 0.6074 - acc: 0.6667 - val_loss: 0.5564 - val_acc: 0.8333\n",
-      "Epoch 13/25\n",
-      "24/24 [==============================] - 4s 157ms/step - loss: 0.5972 - acc: 0.6667 - val_loss: 0.5685 - val_acc: 0.8333\n",
-      "Epoch 14/25\n",
-      "24/24 [==============================] - 5s 214ms/step - loss: 0.5986 - acc: 0.6667 - val_loss: 0.5728 - val_acc: 0.8333\n",
-      "Epoch 15/25\n",
-      "24/24 [==============================] - 6s 263ms/step - loss: 0.6078 - acc: 0.6667 - val_loss: 0.5758 - val_acc: 0.8333\n",
-      "Epoch 16/25\n",
-      "24/24 [==============================] - 6s 239ms/step - loss: 0.5991 - acc: 0.6667 - val_loss: 0.5789 - val_acc: 0.8333\n",
-      "Epoch 17/25\n",
-      "24/24 [==============================] - 6s 242ms/step - loss: 0.5883 - acc: 0.6667 - val_loss: 0.5801 - val_acc: 0.8333\n",
-      "Epoch 18/25\n",
-      "24/24 [==============================] - 7s 301ms/step - loss: 0.5963 - acc: 0.6667 - val_loss: 0.5747 - val_acc: 0.8333\n",
-      "Epoch 19/25\n",
-      "24/24 [==============================] - 7s 299ms/step - loss: 0.6144 - acc: 0.6667 - val_loss: 0.5722 - val_acc: 0.8333\n",
-      "Epoch 20/25\n",
-      "24/24 [==============================] - 9s 358ms/step - loss: 0.6095 - acc: 0.6667 - val_loss: 0.5714 - val_acc: 0.8333\n",
-      "Epoch 21/25\n",
-      "24/24 [==============================] - 7s 311ms/step - loss: 0.5993 - acc: 0.6667 - val_loss: 0.5670 - val_acc: 0.8333\n",
-      "Epoch 22/25\n",
-      "24/24 [==============================] - 10s 403ms/step - loss: 0.6135 - acc: 0.6667 - val_loss: 0.5600 - val_acc: 0.8333\n",
-      "Epoch 23/25\n",
-      "24/24 [==============================] - 9s 395ms/step - loss: 0.6214 - acc: 0.6667 - val_loss: 0.5595 - val_acc: 0.8333\n",
-      "Epoch 24/25\n",
-      "24/24 [==============================] - 8s 348ms/step - loss: 0.6027 - acc: 0.6667 - val_loss: 0.5606 - val_acc: 0.8333\n",
-      "Epoch 25/25\n",
-      "24/24 [==============================] - 8s 329ms/step - loss: 0.6021 - acc: 0.6667 - val_loss: 0.5585 - val_acc: 0.8333\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "history = model.fit(encoder_input_data, gender_data,\n",
     "              batch_size=batch_size,\n",
@@ -324,32 +246,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x1c609968748>]"
-      ]
-     },
-     "execution_count": 100,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAD8CAYAAAB3u9PLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvDW2N/gAAIABJREFUeJzt3Xd4VNXWwOHfSi8EAgQILfTeIXREBJXoRcCGICrYsNer1/rZvbZ7bRcsiAVURCwoKh1BkB56Qg2hQ0IIJYH0ZH9/nEGHkDJJJplkZr3PM0+SM/ucWceRWXP22XttMcaglFJKebk6AKWUUpWDJgSllFKAJgSllFI2mhCUUkoBmhCUUkrZaEJQSikFaEJQSillowlBKaUUoAlBKaWUjY+rAyiJsLAw07RpU1eHoZRSVcr69euPG2PqFNeuSiWEpk2bEh0d7eowlFKqShGR/Y600y4jpZRSgCYEpZRSNpoQlFJKAZoQlFJK2WhCUEopBWhCUEopZaMJQSmlFOAhCeH3HYnMjD7o6jCUUqpSq1IT00rDGMPXqw+wdFcS9WsEcFGrYifrKaWUR3L7KwQR4d3RXWlVtxr3frWBXYmprg5JKaUqJbdPCAAhAb58Or4nAX7e3Pr5OpJSM10dklJKVToekRAAGoYG8um4SJLPZnLntGgysnNdHZJSSlUqHpMQADo3CuW90d3YfOgUj87cRF6ecXVISilVaXhUQgAY2iGcp69ox5ytCby1YKerw1FKqUrD7UcZFeSOi5qxN/ksHy7dQ7PawYzq2djVISmllMt5ZEIQEV4a3oFDJ9N5etZWGtYMpH/LMFeHpZRSLuVxXUbn+Hh7MenGbrSoU427v1pP3DEdjqqU8mwemxDg3HDUSPx9vLn1i3UcP6PDUZVSnsujEwJAo5pBfDoukqTUTCbocFSllAdzKCGISJSI7BSROBF5spA2o0Rkm4jEish027ZLRGST3SNDREbanvtCRPbaPdfVeadVMl0ah/LuDV3ZePAUj323WYejKqU8UrE3lUXEG5gEXAYcAtaJyGxjzDa7Nq2Ap4D+xpiTIlIXwBizBOhqa1MLiAMW2B3+cWPM9846mbKI6lifJ6Pa8trcHTSpHcTjQ9u6OiSllKpQjowy6gXEGWPiAURkBjAC2GbX5k5gkjHmJIAx5lgBx7kOmGuMSStbyOVnwsDm7Es+y6Qle2hSO5hRkTocVSnlORzpMmoI2NeOPmTbZq810FpEVojIahGJKuA4o4Fv8m17VUS2iMg7IuJf0IuLyAQRiRaR6KSkJAfCLT0R4aURHbmoVRhP/7iV9ftPluvrKaVUZeJIQpACtuXvZPcBWgGDgDHAFBEJ/esAIvWBTsB8u32eAtoCPYFawBMFvbgxZrIxJtIYE1mnTvmXrvb19mLS2O7UCPRl6sp95f56SilVWTiSEA4B9n0njYAjBbT52RiTbYzZC+zEShDnjAJmGWOyz20wxhw1lkzgc6yuqUqheoAvl3eox+87jpGZo6OOlFKewZGEsA5oJSLNRMQPq+tndr42PwGXAIhIGFYXUrzd82PI111ku2pARAQYCcSU5gTKy9AO4ZzJzGFlXLKrQ1FKqQpRbEIwxuQA92N192wHZhpjYkXkJREZbms2H0gWkW3AEqzRQ8kAItIU6wrjj3yH/lpEtgJbgTDglbKfjvP0axFGiL8P82ISXB2KUkpVCDGm6oy5j4yMNNHR0SXfMeM0pByBuu1KtNvDMzaybPdx1j49BB9vj5/Dp5SqokRkvTEmsrh2nvEpN/0G+G485JXsfkBUx3BOnM1i3T4dbaSUcn+ekRB63w1JO2DrdyXabWDrOvj7eDE/VruNlFLuzzMSQrvhUL8LLPk35GQ5vFuQnw8Xt67DvJgELWehlHJ7npEQvLxg8HNwaj9snFaiXaM6hpOQksGWw6fLKTillKocPCMhALQcAhF94Y+3IMvx6hlD2tbDx0t0tJFSyu15TkIQgSHPwZkEWDfF4d1qBPnSt0Vt5sUcpSqNyFJKqZLynIQA0KQftLwU/nwbMlIc3i2qYzj7ktPYlXimHINTSinX8qyEADD4WUg/CasmObzLZe3rIYJ2Gyml3JrnJYQG3aD9CFg1Ec46VpaibkgAkU1qMk+Hnyql3JjnJQSAS56B7DSr68hBQzuEs/1oCvuTz5ZjYEop5TqemRDqtIHOo62byyn5C7cWbGiHcACdpKaUcluemRAABj1hlbJY9pZDzRvXCqJjw+p6H0Ep5bY8NyHUbAo9xsOGaXAivrjWAER1CGfDgVMkpmSUa2hKKeUKnpsQAAY+Bl6+sPR1h5pHdbS6jRZot5FSyg15dkIICYfed8GWmZC4rdjmLeuG0KJOsI42Ukq5Jc9OCAD9HwL/EFjyqkPNozqGszr+BCfPOl4kTymlqgJNCEG1oN8DsONXOLy+2OZDO4STm2dYtD2xAoJTSqmKowkBoM89EFQbFr9cbNNODWvQoEYA82M1ISil3ItDCUFEokRkp4jEiciThbQZJSLbRCRWRKbbbc8VkU22x2y77c1EZI2I7BaRb0XEr+ynU0r+IXDRPyF+CexdVmRTEWFox3CW7U7ibGZOBQWolFLlr9iEICLewCTgCqA9MEZE2udr0wp4CuhvjOkAPGz3dLoxpqvtMdxu+xvAO8aYVsBJ4PaynUoZRd4O1RtaVwnFVDWN6hBOVk4eS3cmVVBwSilV/hy5QugFxBlj4o0xWcAMYES+NncCk4wxJwGMMceKOqCICDAY+N62aSowsiSBO51vAAx8HA6thV3zi2wa2bQWtYP9dLSRUsqtOJIQGgIH7f4+ZNtmrzXQWkRWiMhqEYmyey5ARKJt28996NcGThljzvW5FHTMitftJqjZDH5/BfLyCm3m7SVc3qEev29PJCM7twIDVEqp8uNIQpACtuXvU/EBWgGDgDHAFBEJtT0XYYyJBG4E3hWRFg4e03pxkQm2hBKdlFTOXTTevlbhu8StsG1WkU2HdgjnbFYuK/ccL9+YlFKqgjiSEA4Bje3+bgTkrwh3CPjZGJNtjNkL7MRKEBhjjth+xgNLgW7AcSBURHyKOCa2/SYbYyKNMZF16tRx6KTKpOO1ULcD/P4q5BZ+07hfizBC/H20tpFSym04khDWAa1so4L8gNHA7HxtfgIuARCRMKwupHgRqSki/nbb+wPbjLUW5RLgOtv+44Cfy3oyTuHlZS2ic2IPbJxWaDM/Hy+GtKvLwm2J5OQW3r2klFJVRbEJwdbPfz8wH9gOzDTGxIrISyJybtTQfCBZRLZhfdA/boxJBtoB0SKy2bb9dWPMuRoRTwCPikgc1j2FT515YmXS5gpoMgAWvQBnCr8/HtUxnJNp2azdd6LiYlNKqXIiVWnh+MjISBMdHV0xL5a0Cz7qb62udu2UApukZeXQ/eWF3BDZmBdHdKyYuJRSqoREZL3tXm6RdKZyYeq0hgGPwtbvIG5RgU2C/Hy4uHUd5scmkpdXdRKrUkoVRBNCUS56FGq3gl8fhay0AptEdQwnISWDzYdOVXBwSinlXJoQiuLjD1e9C6f2wx9vFNhkcNt6+HiJTlJTSlV5mhCK03SANWFt5f8gIeaCp2sE+tK3RW3mxyRQle7HKKVUfpoQHHHZyxBYE355yFqHOZ+ojuHsS05jZ2KqC4JTRTmTmUNWjg4LVsoRmhAcEVQLol6Dw9EQ/dkFT1/Wvh4i6CS1SiYvzzDs/eW88Eusq0NRqkrQhOCoTtdD80tg0YuQcvS8p+qGBBDZpKYmhEpm86FT7EtO4+eNh0nP0ppTShVHE4KjRGDY25CXDXP/dcHTQzuEsyMhlRVxWtuosjh3o/9sVi4LdYU7pYqlCaEkajWHi/8F22fDzrnnPXVDz8a0rFuN+6ZvYN/xsy4KUJ1jjGF+TAIDWoZRv0YAP2087OqQlKr0NCGUVL8HoW57+O0xyDzz1+aQAF8+HWdNBLxjWjQpGdmuilABuxLPsC85jaiO4Yzo2pA/diWRfCbT1WEpValpQigpb1+46j1IOQxLXj3vqSa1g/lgbHf2HT/Lg99sJFdnL7vM/NgERODy9vW4ultDcvMMv245WvyOSnkwTQil0bgXRN4Gaz6CIxvPe6pfizBeHNGBpTuTeG3OdhcFqObFJNA9oiZ1qwfQJjyE9vWrM0u7jZQqkiaE0hryHATXgdkPXrBuwtjeTRjXtwlT/tzLzHUHCzmAKi8HT6Sx7WgKUR3C/9p2dbeGbDp4ir16f0epQmlCKK3AULjiDUjYAms/vuDp/xvWngEtw3jmp62s0/LYFWq+bXTRULuEMLxrA0TQm8tKFUETQlm0Hwmthlqrq506/0rAx9uLSTd2p1HNIO7+cj0HTxRcHE853/zYBNrVr05E7aC/ttWrHkD/FmH8tOmwlhhRqhCaEMpCBP7xH8DAnMcg3wdNjSBfpoyLJCs3jzunRXMms/AlOZVzJKVmEr3/JEM71LvguZHdGrI/OY0NB7QyrVIF0YRQVqERcMkzsGsebLtwFdAWdaox6cbu7EpM5eEZm3TdhHK2cFsixlj1pfIb2qEeAb5e2m2kVCE0IThD77uhfheY+wRkpFzw9MDWdfi/Ye1ZtD2R/yzY6YIAPce82ASa1A6iTb2QC54LCfDlsvbh/LrliBa8U6oADiUEEYkSkZ0iEiciTxbSZpSIbBORWBGZbtvWVURW2bZtEZEb7Np/ISJ7RWST7dHVOafkAt4+8I934EwCrJpUYJPx/ZoyplcEHyzdo99Qy8np9GxW7TlOVIdwRKTANld3a8DJtGyW7Uqq4OiUqvyKTQgi4g1MAq4A2gNjRKR9vjatgKeA/saYDsDDtqfSgFts26KAd0Uk1G7Xx40xXW2PTWU/HRdq1MO6ybxqIpy58MNGRHhxeAd6N6vFv37YwsYDJyskrA0HTjL4P0s5kOz+N7WX7DhGdq7h8g4Xdhedc1GrOtQK9mPWJk3KSuXnyBVCLyDOGBNvjMkCZgAj8rW5E5hkjDkJYIw5Zvu5yxiz2/b7EeAYUMdZwVc6g5+F7HRY/t8Cn/bz8eLDm3pQr7o/d05bz5FT6eUajjGGl3/dRvzxs3y5el+5vlZlMD82gboh/nRrHFpoG19vL67qXJ9F2xK1vIhS+TiSEBoC9mMqD9m22WsNtBaRFSKyWkSi8h9ERHoBfsAeu82v2rqS3hER/xLGXvmEtbJWV4v+FE7uL7BJrWA/Ph3Xk/SsHO6cFk1aVvmNPFqwLZGNB04RVs2P79YfIiPbfUtAZ2TnsnRnEpd3qIeXV8HdReeM7NaQzJw8LVeuVD6OJISC/nXlHyrjA7QCBgFjgCn2XUMiUh/4ErjVGHPubt5TQFugJ1ALeKLAFxeZICLRIhKdlFQF+n0vfgLEC5a+VmiT1vVCeH9MN7YdTeHJH7aWSxg5uXm8NX8nLeoE8/aorpxKy+Y3N67ls2xXEunZuUR1qF9s266NQ2laO0jv5SiVjyMJ4RDQ2O7vRsCRAtr8bIzJNsbsBXZiJQhEpDrwG/CsMWb1uR2MMUeNJRP4HKtr6gLGmMnGmEhjTGSdOlWgt6lGQ+g1ATbPgMRthTYb0q4eDw9pzezNR1hcDrX6f9hwiLhjZ3h8aFsuahVG87Bgvl5T8FWLO5gXm0CNQF96N69VbFsRYWS3hqyKT+bo6fLttlOqKnEkIawDWolIMxHxA0YDs/O1+Qm4BEBEwrC6kOJt7WcB04wx39nvYLtqQKzhICOBC1ewr6oGPAL+1eH3l4tsds+gFrSqW43nfo51atdRRnYu7yzcTbeIUIZ2qIeIcGPvCDYcOMW2IxcOi63qsnPzWLz9GEPa1cXX27GR1CO7NsQY+HlT/u82SjnOGONWVY2L/ddjjMkB7gfmA9uBmcaYWBF5SUSG25rNB5JFZBuwBGv0UDIwChgIjC9geOnXIrIV2AqEAa849cxcKagW9H8Qds6BA2sKbebn48WrV3fi8Kl03lu822kvP3XlPhJSMngiqu1fwy+v69EIfx8vviqnq4RftxxhV2JquRy7OGviT3A6Pfu82kXFaRoWTLeIUO02UqW25dApot5dzqiPV5GT6x7zWhz6OmWMmWOMaW2MaWGMedW27TljzGzb78YY86gxpr0xppMxZoZt+1fGGF+7oaV/DS81xgy2te1ojLnJGHOm8AiqoD73QHBdWPTCBSUt7PVqVotRkY34dPlediSU/dv76bRsJi2J45I2dejTvPZf20OD/BjWuQE/bzzs9BIaMYdPc//0jdz86RqXLEIzPzaBQF9vBrYqWZfiNd0asiMhle1H3e+qSZWfrJw8/rtgJ1d/sJKElAzW7z/J1FXu0R2rM5XLi1+wtdzmgZUQt6jIpk9e0Y6QAB+emRVT5tIWH/6xh9TMHP4V1faC527qE8HZrFynrwvwzsJdhPj7cDItm0dmbq7Q8hx5eYb5sQlc3LoOgX7eJdr3H50b4OMlepWgHBZ75DTDJ/7J/36P4+puDVn2r0sY1KYOby/YWe7DyCuCJoTy1H0c1GwKi16EvMIvKWsF+/H0le1Yv/8k30aXfv2Eo6fT+XzFXkZ2bUi7+tUveL5r41A6NKjO16v3O63i54YDJ1m84xh3D2rBc8Pas2xXEh/+saf4HZ1k06FTHEvNZGjHC4vZFadWsB+D2tTh501H3KofWDlfdm4e7y/ezYiJK0g+m8WUWyL5z/VdqBHoy8sjOpJrDC/MjnV1mGWmCaE8+fjBJc9C4laI/bHIptf1aETvZrV4fe4Ojpey2+W9RbsxBh69rHWBz4sIY3s3YUdCKhucNFP67QW7qBXsx/h+TRnbO4Jhnevz9sJdFbYGxPyYBHy8hMFtS54QwJqTkJCSwZr4ZCdHptzFrsRUrvlgJW8v3MU/OtdnwcMDubT93/+/Na4VxMOXtmbBtsS/1uKoqjQhlLeO10K9jtaIo5ysQpuJCK9e3ZG0rBz+/VvJl96MO3aGmdEHGdsngsa1ggptN6JrA6r5+/DV6gMlfo38Vscn82fcce4d1IJgfx9EhNeu6UTjmoE8MH0jJ84Wfr7OYIzVXdS3RW1qBPqW6hiXtqtHNX8fXV5TXSAnN48Pl+5h2Pt/cuRUOh+O7c57o7tRM9jvgra3D2hG2/AQXpgdW6XL3GtCKG9eXjDkeTi5DzZOK7Jpy7oh3DWwBT9uPMzKPcdL9DJvzd9BkJ8P91/Sssh2wf4+XNO9Ib9tPVqmD2xjDG8v2EXdEH9u6tPkr+0hAb5MvLE7J85m8ejM8i33vTMxlX3JaQWWunZUgK83V3QMZ25MglvP5FYlsyfpDNd9tIo35u1gSLu6zH9kIFd0KnzSo6+3NWLw6OkM3lm4qwIjdS5NCBWh1WUQ0Q/+eBOyil7T9/7BLYmoFcSzs2LIzHHsA2rDgZPMj01kwsDm1K5WfAWQsb2bkJWTx/frS3+/Yvnu46zdd4IHBrckwPf8m7kdG9bg/4a1Y+nOJCYvjy/1axRnfkwiInBZ+9J1F51zdbeGnMnMYVE5TBBUF0pKzWT6mgPlfgVZGrl5hinL47nyveXsSz7L+2O68cHY7oQ58O+qR5OajO0dwecr9hJz+HQFROt8mhAqgghc+gKcSYQ1HxXZNMDXm5dHdiT++Fk+Wlr8h6kxhtfn7iCsmj+3D2jmUDhtwkPo2bQmX685UKpv8MYY/rtgJw1DAxnVs3GBbW7q04R/dKrPW/N3El1O9xPmxSbQI6ImdUMCynSc3s1rE149QEcbVQBjDI/O3MTTs7bS57XF/HPmZrYcqhwr2CWmZDB68ipe+W07F7UKY8EjAxnepUGhpdQL8q+ottQK9ufpWVur5EAFTQgVJaI3tLkS/nwP0or+gLy4dR2Gda7PpKVx7D1e9BXF0p1JrN17ggeHtCTY38fhcG7q04T9yWmsKGHXFMCi7cfYfOg0Dw1phb9PwUM9RYTXru1Ew9BAHvhmIyed/G3wQHIa24+mlGgyWmG8vYQRXRuwdGeSS+ZReJIfNhxm+e7j3HdJC26IbMzcmKMMn7iCkZNW8NPGww5fFTtbelYud0yNJvZICv+9vguf3BJZqi8aNQJ9ef6q9mw5dJovV+1zepzlTRNCRRr8f5CZAiveLbbpc8Pa4+/txf/9FFPoENG8PMMb83bQpHYQo3tGlCiUqI7h1Ar246vVJZtQk5dnXR00rR3ENd3zF709X/UAXybd2J3kM1n88zvnzk84N5rDGQkBrNFGOXmG37a6bwFAV0tKzeTlX7cR2aQm/7ysDS+P7Mjqp4fw/FXtSUnP5uFvN9H/9d/574KdFVpjyhjDv37YQsyR0/xvTDeu7dGoRFcF+Q3rXJ+BrevwnwW7qlytLE0IFalee+gyGtZ8DClF19CpWz2Ax6Pa8GfccWZvLrjtz5sPsyMhlX9e3gY/n5K9lf4+3lwf2YhF24+RcDrD4f3mxBxlR0IqD1/aGh8H6gZ1alSDZ/7Rjt93HGPKn867nzA/NoF29asTUbvwEVUl0a5+ddqGh+hoo3L0wi+xpGfl8vq1nf8qUV49wJdb+zdj0aMXM+22XnRtHMrEJXEMeGMJ9369ntXxyU6bM1OYSUvi+GXzEf41tC1D2pXtfhRYV8evjOhIdm4eL84uvMBlZaQJoaINegrycuGPN4ptOrZ3E7o0qsHLv27jdNr5i7lk5uTyn/m76NCgOsOKGP1Q5PF7NSHPGGasc2wIak5uHm8v3EWrutW4qksDh1/nlr5NuKJjOG/M28n6/WWf/3AsNYP1B04S5aSrg3NGdmvIxgOn2FdMN50quQWxCfy25SgPDmlJy7rVLnjey0sY2LoOU8b1ZNnjl3DHgGasiEtm9OTVRL27nK/X7C+XtUPmxybwnwW7uLpbQ+6+uLnTjhtRO4iHLm3FvNgEFm2rOoMVNCFUtJpNoOftsOFLOF50QTtvL+HVqztx4mwWb87fcd5zX68+wOFT6Tx5RdtiF4QpTETtIAa2qsOMtQcdKs7186YjxCed5dHLWuNdgtcUEd64rjMNQgN4YPoGTqWV7X7Cwm2JGEOpZicXxbqBCD/p8ppOlZKRzf/9HEPb8BDuurhFse0b1wriqSvbsfqpIbx5bWe8vYRnZsVw5XvLi72nVhLbj6bwyLeb6NI4lNeu6VSmbqKC3HlRc9rUC+H52bGcrSJzEzQhuMJFj4FPAPxefIHXjg1rML5fM6avPfDX7OLUjGwmLomjf8vaXFTCgm75je0dQUJKBou2HyuyXXZuHu8t3k2HBtVL1W9/7n5C0plMHvtuc5m6AebFJNC0dhBt6oWU+hgFaRAaSJ9mtflp4+Fy76YoKWMM24+mVMmqmq/N2UFSaiZvXtfZ4fLkAIF+3ozq2ZjfHhzAV7f3JiUjh2s+WOGUUWvJZzK5Y2o0IQE+TL65xwVDp53B19uLf1/TkcOn0nl3UdWYm6AJwRWq1YF+98O2n+DwhmKbP3p5a8KrB/D0j1vJyc3jk2XxnDibxRMFFLArqcFt61K/RkCxi+d8v/4QB06k8c/LW5f6iqRzo1CevrIdi7Yf49M/95bqGKfTs1m1J5mhHcKd/o0OrDkJ+5LTKtU6CRnZuTz+/RaueG85N0xezeEqVERtdXwy36w9wO0DmtG5UeFrXRdFRBjQKoxZ9/YjNMiPG6es4dctpX9/snLyuOfrDRw/k8nkmyOpV71sw5aL0qNJLcb0iuCzFfuIPVL55yZoQnCVvvdDYC1Y/GKxTav5+/D8VR3YkZDKWwt2MuXPvfyjc/1S/wOz5+PtxZheESzffbzQvvOM7FzeX2wtuHNJm7pler3x/ZoytEM9Xp+7o1T1lH7fkUhOnmFoGWYnF+WqLg3oHhHKIzM3MaUcJ9U56uCJNK77aCXfrz/Etd0bseNoCle+t5wFVaBmTkZ2Lk/+sIWIWkE8elmbMh+vSe1gfrynH10a1eD+6Rv56I89Jb6SM8bw/OxY1u49wZvXdaZL47L/GyrOk1FtqRnky9OzYir93ARNCK4SUB0GPgbxS61HMYZ2qMeQtnX5+I94snLyeOzysv8DO+eGno3x9hK+WVvwzeUZaw9w9HQGj13epszfykWEN6/rQniNAB6YvpEvVuxldXyyw/cV5sckUjfEn65OSIYFCfTzZvqdfRjaPpxXftvOi7/Euuwf8bJdSVw18U/2J6fx6bhI/juqC789eBGNawUy4cv1vDA71mXj9h3x7qLd7EtO47VrOpW4NHlhagb78eXtvbmqSwNen7uDZ3+KKVE32rRV+/lm7QHuHdSCEV2LHjbtLDWCfPm/Ye3ZfPBUpV/GVhOCK0XeDtUbWeWxi/mmIyK8OKIDIf4+3NSnCc3Cgp0WRr3qAVzevh4zow9eUM8nPSuXiUv20Kd5Lfq1qF3IEUqmRqAvH4ztTm6e4YVftjF68mq6vrSQvq8t5tbP1/LGvB38vOkwuxJTybb7x56elcvSXccY2iG81N1Wjgjw9WbS2O7c1r8Zn6/Yx31fb6jQOkfGGCYtiWPc52upFxLAL/cP+Gs4ZNOwYH64px+39m/KFyv3cc0HK516o9VZYg6f5pPl8YyKbET/lmFOPXaArzfv3dCVewa14Os1B7hjWrRDBeVWxB3npV+3cWm7ek79QuWI4V0acFGrMN6ct5PEFMeHeVc0qWw3z4oSGRlpoqOjXR2Gc238Cn6+D0Z9Ce2HF9v8dHo21QN8nN5/viLuOGOnrOGdG7pwdbdGf23/+I89vDZ3B9/d3ZeeTYtfwL4kjDEkpWayPSGVHUdT/lq9bE/SGbJzrf8v/by9aFm3Gm3rh+Dv48U3aw/y1e29GdDKuR8yhfn0z7288ts2ujUOZcq4ntQqoNKlM6VmZPPPmZtZsC2R4V0a8Pq1nQjyK3gG+sJtiTz+/Wayc/J49epOjOxWMd94i5Odm8eIiStIOpPJokcupkZQ6SrROmL6mgP8388xtKkXwmfjexJeo+D7AfuOn2XEpBXUq+7Pj/f2p1oJZvU7y/7ks1z+zjIubVePSWO7V+hri8h6Y0xkse0cSQgiEgW8B3gDU4wxrxfQZhTwAmCAzcaYG23bxwHP2pq9YoyZatveA/gCCATmAA+ZYoJxy4SQmwMf9gMM3LMKvCv+f1SwZiAPefsPagcRpeFFAAAgAElEQVT78f09/QDrw2ngm0vo1CiUabf1qrBYsnLyiD9+hh1HU9mekMKOo6nsSEghMSWTsGr+rHpqcIlGq5TV3K1HefjbTdSvEcAXt/aiqROvzuztTkzlrq/Wsz85jaevbMdt/ZsWm/iPnErnoRkbWbfvJNf3aMSLIzoUmkAqygdL43hz3k4+uqk7UR1LN0emJJbuPMZ9X2+geqAvn43vecHiUCkZ2VzzwUqSz2Ty830DnDaZsTQmLYnjrfk7uahVGNUDfAny8ybY3+evn4G+3gT7exPk5/PXzyA/62fjWoGFloopjtMSgoh4A7uAy4BDwDpgjDFmm12bVsBMYLAx5qSI1DXGHBORWkA0EImVKNYDPWxt1gIPAauxEsL7xpi5RcXilgkBYPsv8O1NMHwidL/ZZWFMWR7PK79tZ97DF9E2vDrvL97N2wt38fN9/Svk5ltxzlXHLO9v6QVZv/8Ed0yNRkT4dFwk3SJqOvX4c7Ye5fHvNhPo583EG7uftx52cXJsQ4InLomjRZ1qTLyxG23DL1wxryLEJ50h6r3lDG5Tl49u7lFhr7vtSAq3fbGOM5k5fDC2OwNbW8Oxc/MMd0xdx/Ldx/ny9t70dVK3Z2ll5eTx7E9b2ZmQytmsXNIyc6yfWTl/XRUXZtGjA2lZt3RDrZ2ZEPoCLxhjhtr+fgrAGPOaXZs3gV3GmCn59h0DDDLG3GX7+2Ngqe2xxBjTtqB2hXHbhGAMTBkCqQnwwAbwLb9hcEU5lZZFr38vZlRkIx6/vC0D3vydPs1r88ktxf5/5BHik84w/vN1HEvN4P3R3bjcCTOlc3LzeGv+Tj5eFk+3iFA+HNuj0G6P4qyMO85D324iJT2b565qz429IsplaG5h8vIMoz9ZzY6jKSx69GLqluNwzoIcPZ3OrZ+vY/exM/z76o7c0DOC1+Zs5+Nl8bwysuN563ZURlk5eaRn5XI2K4e0rBzOZlq/W9tyGdy2bqm7uhxNCI5cdzcE7AvnH7Jts9caaC0iK0Rkta2Lqah9G9p+L+qYnuNceeyUw7BuSnGty01okB/DOtdn1obDvLNoF6kZOYUux+mJmtepxo/39qNNeHXu+mo9U1fuK9Pxks9kcstna/l4WTw39YlgxoQ+pU4GAP1ahjH3oYvo3bw2z8yK4f7pG0nJyC5+Ryf5Zt0B1u49wTP/aFfhyQCgfo1Avru7L/1bhvHED1u5Y+o6Pl4Wz819mlT6ZADg5+NFjSBfGoQG0rJuCF0ah9KvRRhD2tVjeJcGFXLfw5GEUNBXjPyXFT5AK2AQMAaYIiKhRezryDGtFxeZICLRIhKdlJTkQLhVVLOB0GIwLP8vZLhuAstNfZpwNiuXL1buY1jn+hf0x3q6sGr+zLizD5e2q8fzs2P595ztJarimpWTx8ETaSzenshV//uT6P0neeu6zrwyslOp+4fzx/fF+J48eUVb5scmMOz9PyukNlPC6Qxen7ODfi1qMyqy4DUyKkJIgC+fjotkdM/GLNp+jL7Na/PcVe1dFk9V40jKOQTYv8ONgPzTBA8Bq40x2cBeEdmJlSAOYSUJ+32X2rY3yre9wKmHxpjJwGSwuowciLfqGvIcTB4EKyfC4GdcEkK3xqG0r1+dHQkpPHypXh0UJNDPm49u6sGLv8QyeVk8h0+l89/ruxDg683p9GyOnErnyKl0DtseR05lcPhkGkdOZZCYmvHXCOOGoYH8cHc/OjWq4dT4vLyEuy9uQc+mtbhzWjTXfbSKabf1on2D8knuxhie/Wkr2Xl55VITqKR8vb147ZpODOvcgK4RoRU6AKGqc+Qegg/WTeUhwGGsm8o3GmNi7dpEYd1oHiciYcBGoCt/30g+N8ZqA9ZN5RMisg54AFiDdVP5f8aYOUXF4rb3EOx9Nx52LYCHNkG1ss0KLq1NB0+xP/lshU3cqaqMMXyyPJ5/z9lBnRB/MrJySc03Ht7P24sGoQE0CA2kQWggDW2PBqGBdI0ILfdugLhjZ7j50zWcyczh8/E9iXTy0GGAXzYf4YFvNvL0lW2ZMLD44nWq4jl72OmVwLtYw04/M8a8KiIvAdHGmNlifSX4LxAF5AKvGmNm2Pa9DXjadqhXjTGf27ZH8vew07nAAx457DS/43EwqRf0vAOufNPV0SgHzItJYPbmw9QNCfjrw75BaAANawYSFuxfrpPoHHH4VDo3T1nDkdPpfHRTDwaVsfyIvQ0HTnLn1GgahAYy695+Dq2RoSqeUxNCZeERCQHgl4dg49fwQDTUbOrqaJQbOH4mk3GfrWVnQipv39CV4SVYz6IgWTl5vLd4Fx8u3UP9GoF8cWtPWjm5+qxyHmeOMlIV7eInwMsblrxWfFulHBBWzZ9vJvShe5OaPDRjY4mXTrW3/WgKIyatYNKSPVzbvRFzH75Ik4Gb0IRQGVVvAL3vgi3fQmJs8e2VckD1AF+m3daLwW3q8uxPMUxaEleiaqG5eYYPl+5h+MQ/SUrN4JNbInnr+i5UDyi/0hSqYmlCqKz6Pwz+1WHxy66ORLmRAF9vPrq5ByO7NuCt+Tt5be4Oh5LCvuNnGfXxKt6Yt4NL29Vj/sMDuay9c1esU67n2qInqnBBtWDAQ7D4JTiwGiL6uDoi5SZ8vb14e1RXagT6MnlZPKfSsvj31Z0KvCFsjOGrNQf492/b8fUW3r2hKyO6NnD50FJVPjQhVGa974E1k2HRC3DrXGtGs1JO4OUlvDC8AzWC/Hh/8W5S0nN4b0zX8ybHHT2dzr++38Ly3cet0s3XdaZ+jUAXRq3Km3YZVWZ+QXDxv+DAKti90NXRKDcjIjx6WWueG9aeebEJ3P5FNGczczDG8NPGwwx9ZxnR+07y8siOTLutlyYDD6DDTiu73GyY2BP8guGu5eClOVw53w/rD/GvH7bQqWENGoQGMGdrAj2a1OS/13cpt3LfquLosFN34e0Lg5+FxBiI+cHV0Sg3dW2PRnw4tjvbjqawaNsxnryiLTPv6qvJwMPoFUJVkJcHkwdCZirctw58Kn49AOUZdiak4ustNK9TzdWhKCfSKwR34uUFQ16Ak/tgw1RXR6PcWJvwEE0GHkwTQlXRcgg0GQB/vAmZZ1wdjVLKDWlCqCpE4NLn4ewxWDvZ1dEopdyQJoSqpHEvaDEEVn8I2RmujkYp5WY0IVQ1/R+yrhK2zHB1JEopN6MJoappNhDqd4WV/4O8XFdHo5RyI5oQqhoR6yohOQ52FrnAnFIlk5kKx3e7dE1v5Vpay6gqajfcWjjnz3eh7TCtcaSKlpMJqQm2xxHbz6PWz5Qjfz+XlWq19w2G7rdA33shNMK1sasKpQmhKvL2gb73w5zHrDpHTfq5OiJVWeTlQsIW2LsM4v+Ao5sgLfnCdt5+EBIOIQ2gXgdoean1d7V6EL8U1n1ijWbrcDX0fxDqd6nwU1EVz9E1laOA97DWVJ5ijHk93/PjgbeAw7ZNE40xU0TkEuAdu6ZtgdHGmJ9E5AvgYuDc9el4Y8ymouLw2JnKBclKg3c7QqOecOO3ro5GuYoxcHyXLQEshX1/QsYp67mwNhDRG2o0hpD6tke4tQBTYM2iryxPH7JGs62fal05NLvYSgwthugVaRXktDWVRcQb2AVcBhwC1gFjjDHb7NqMByKNMfcXcZxaQBzQyBiTZksIvxpjvi/+dCyaEPJZ+gYs/TfcuxrqtnN1NKqinDoIe/+wrgD2LoMzCdb2GhHQfKD14d1soPXhX1bpp2D9F1ZyOJMA9TpCvweh4zVWnS1VJTiaEBzpMuoFxBlj4m0HngGMALYVudeFrgPmGmPSSrifKkyvO2HFu9aIo5EfuDoaVV5SE2HfcusR/wec3GttD65jffA3syWBmk2d/+09MBQGPAx97oGt31n/r82aYC3c1Oce6DEO/HU9ZXfhSEJoCBy0+/sQ0LuAdteKyECsq4lHjDEH8z0/Gng737ZXReQ5YDHwpDEm07GwFWCtqtbtZoj+DC55Bmo0dHVEyhnOJsP+P2HvcusK4PhOa7t/dWjS31pvu9lAqNu+4rpvfPyh203Q5UaIWwgr3ocFz1ilVCLHQ5srrfsMvrpmQlXmSJfR9cBQY8wdtr9vBnoZYx6wa1MbOGOMyRSRu4FRxpjBds/XB7YADYwx2XbbEgA/YDKwxxjzUgGvPwGYABAREdFj//79ZTlf93NyP7zfzRoRcvkrro5GlUb6Kdi/0vrw37fcKnUO1mifJn2h6UXQ7CII72INKKgsDq+3EsP22WDyQLytG9QNe/z9qNMGvLyLP5YqV868h9AXeMEYM9T291MAxpjXCmnvDZwwxtSw2/YQ0MEYM6GQfQYBjxljhhUVi95DKMT3t8Ou+fBIjHWJryq3vFzr5m/cQusqIGGL9YHqEwCNe1sf/k0HQsPuVaOf/swxOBRtJYjD0XB4I2Taxor4VYMG3axzOZckqjfUG9MVzJn3ENYBrUSkGdYootHAjflerL4x5qjtz+HA9nzHGAM8VdA+Yq3WPRKIcSAWVZD+D0LM97D+cxjwiKujUYU5vhs2TYct30LKYWvoZ6OecPET1lVAo0ira6aqqVYX2l5pPcBav+PEHitBnEsUqz6AvGxb+3AI72TdAwmqZT0CbT+Dav/9e2AtXfujghWbEIwxOSJyPzAfa9jpZ8aYWBF5CYg2xswGHhSR4UAOcAIYf25/EWkKNAb+yHfor0WkDiDAJuDuMp+Np6rfBZpfYo0E6XNv1fxQcVfpJyHmRysRHI62ulVaDrG691pHWetmuxsvLwhrZT26jLa25WRCQoztCmI9HNtuPdJPQHYR40z8QiCoppUcwjtZx4vop0vJlhNdMc1d7FkCX46E4ROh+82ujsaz5ebAnsVWEtg5F3IzrRvAXW+ETqMgpJ6rI6xcstMh7YSVHNJOWBPp0k9A2sm/fz97HA6uteZEhEZAlzFWcqjV3NXRVwlOu4dQmWhCKIIx8PFAyMmAe9foNyhXSIy1dQnNtCrSBtWGTtdbH171u2i/eVllpcGOX63/xvFLAQMRfa3/vh1GQkCN4o7gsTQheKKt38MPt8Pob/7uz1Xlb+9ymP+0dXPYy8fqCuoyBlpdrn3g5eX0IetezKZvIHm3dUO+7TDoOsbqPtWRTefRhOCJcnPgf92s+jS3z3d1NJ5h35/w1XVQvT70vhs6XgfBtV0dlecwxronsWk6xPxgle0IqQ+dR1lzJuq2dXWElYKjCUH7FdzJuaJ3B1fDgdWujsb9HVwL02+Amk3g9oXWhDFNBhVLxBqdNexteGwXXD/V6p5bORE+6A3f3mRdTSiHaEJwN91usgqXrXjf1ZG4t8Mb4KtrrSGXt/wMwWGujkj5+Fv3Em78Fv65AwY9DbsXwcReVqn4nCxXR1jpaUJwN37B0GsC7PwNkna5Ohr3lBADX15tTQIc94tzisgp56pWFwY9AfetgeaDYNHz8NEAaza4KpQmBHfUa4J1k22lXiU4XdJOmDbCSrzjfoEajVwdkSpKzSYwZjqM+dYagTf1KvjhDmtBIHUBTQjuKDjM6jra8i2kHC2+vXJM8h6YOtwawXLLbKu6qKoa2kRZVwsXPwHbfoaJPa2JnLk5ro6sUtGE4K763gd5ObDmI1dH4h5O7reSQV62lQzCWro6IlVSvoFwydPW+iGNesK8J2HyIDiwxtWRVRqaENxVrebQfoRVGjsjxdXRVG2nD1tdDVlnrBvIOpSxaqvdAm76AUZNs2ZBf3Y5/HSfNRu6ImSlWcNlK6FKVEtXOV2/ByF2lrXiVf8HXR1N1ZSaCNOGWzWJbvnJqqejqj4R6wtTiyGw7E1YNcmaBX3RP6FWM/ANsu4TnfczyCpJXlAJcmOsORCpCdbjTOL5P1MTrBXnUhMh+6y1tkW9DnaPjtaqhy5ebEgnprm7qVdZVTYf2qKzZkvqbDJ88Q84dQBu/hEi+rg6IlVeju2AOY9Z61EUx9vP6n7yDbaSRG6W9UGfW8D6Xn7VoFo923rW9axKr8G1IeWIVeokMRYy7a7gaza1koN9oqjZtMwzr51Z/lpVZf0fssbLb/0Ouo11dTRVR/pJ+HKEtVzl2O81Gbi7um2tUWMn90JmqtWtk217ZKVZ3+rPbcs6e/5z3r62D/1wuw9/2+/+1Yp+XWPg9EFbcoj5O0nsnGOtkQHW1UnddnD15HK/d6UJwd21GGJ9y1j5P6vaphZYK15GipVEk3bCmG+sBWuU+xOp+OqpIlb11tAIaHPF39uz0yFpx98JIjHGWiOinGlCcHci0O8BmHUX7F4IrS93dUSVW2YqTB8FRzfDqC+h5aWujkh5It9Aa6W5Bt0q9GV1lJEn6HittWyhTlQr2tnj1j2Xg2vh2ilaMVZ5HE0InsDbF/rcY90wO7ze1dFUTqcOwmdR1ipeo6dDh6tdHZFSFU4TgqfoPg78a2jRu4Ic2wGfXm4tFn/zT9asVqU8kCYETxFQHSJvhe2z4cReV0dTeRyKhs+jwOTCrXOgSV9XR6SUyziUEEQkSkR2ikiciDxZwPPjRSRJRDbZHnfYPZdrt3223fZmIrJGRHaLyLciooPky1vvu61F3ldNcnUklUPcYqscRUANuG0+hHd0dURKuVSxCUFEvIFJwBVAe2CMiLQvoOm3xpiutscUu+3pdtuH221/A3jHGNMKOAncXvrTUA6pXh863wAbv7ImXXmymB+txW1qNYfbFlizU5XycI5cIfQC4owx8caYLGAGMKIsLyoiAgwGvrdtmgqMLMsxlYP6PQA56bBuSvFt3dW6KfD9bVaBs/G/WjNIlVIOJYSGwEG7vw/ZtuV3rYhsEZHvRaSx3fYAEYkWkdUicu5DvzZwyhhzrvZsYcdERCbY9o9OSkpyIFxVpLptrUXg135szbL0JMbA0jfgt39a/w1u/tFa5EYpBTiWEAqa2pq/ANIvQFNjTGdgEdY3/nMibDU0bgTeFZEWDh7T2mjMZGNMpDEmsk6dOg6Eq4rV70FIS4bN010dScXJy4O5T8DSf1uLr9/wlTX5Ryn1F0cSwiHA/ht/I+CIfQNjTLIx5lxlp0+AHnbPHbH9jAeWAt2A40CoiJybKX3BMVU5atIPGvawFiLPy3V1NOUvJwtmTbCuivreDyMmFVyxUikP50hCWAe0so0K8gNGA7PtG4hIfbs/hwPbbdtrioi/7fcwoD+wzVglVpcA19n2GQf8XJYTUSUgYl0lnNxrlfx1Z1lnYcYYq7jfpS/A5a+Al462Vqogxf7LsPXz3w/Mx/qgn2mMiRWRl0Tk3KihB0UkVkQ2Aw8C423b2wHRtu1LgNeNMdtszz0BPCoicVj3FD511kkpB7S7Cmo2gxXvVdrFOpzi25tgz+9w1fsw4BEt7qdUEXQ9BE+2bop1g3X8HGja39XROF/iNviwr3VlMOARV0ejlMs4uh6CXjt7sq5jIai2+xa92zLDmojX9SZXR6JUlaAJwZP5BkKvCbBrnlXPx53k5cKWmdDqMqimo9OUcoQmBE/X807wCYRV/3N1JM619w9IPQpdRrs6EqWqDE0Ini64NnS7yfo2nXLU1dE4z+Zvrequra8ovq1SCtCEoAD63gd5ObDmI1dH4hyZZ6yqrh1Ggm+Aq6NRqsrQhKCswm7thkP059YSklXd9l+sBdC7jHF1JEpVKZoQlKX/g5B5GtZPLb5tZbf5GwhtAhF9XB2JUlWKJgRladgDmgyA1R9Cbraroym904dh7zLr6kAnoSlVIpoQ1N/6PwQph6y1AqqqrTMBA11ucHUkSlU5mhDU31pdBnXaVd1yFsbA5hnQuLe18I1SqkQ0Iai/iVgL6ByLhT2LXR1NyR3dDEk7dO6BUqWkCUGdr9P1EFIfVlTBchabZ4C3H3S42tWRKFUlaUJQ5/Pxs8pZ7P0Djm13dTSOy822Sly3uQICa7o6GqWqJE0I6kLdx4G3P6z9xNWROC5uMaQdh87aXaRUaWlCUBcKrm11HW2eARmnXR2NY7bMsCq3trzU1ZEoVWVpQlAF63UnZJ+FTVVg3eX0U7BjDnS8zuryUkqViiYEVbAGXa3hm2snWwvUV2bbfoLcTB1dpFQZaUJQhes1AU7EW0tQVmabZ0BYa2jQzdWRKFWlOZQQRCRKRHaKSJyIPFnA8+NFJElENtked9i2dxWRVbb1lreIyA12+3whInvt9unqvNNSTtFuOFSrB2s/dnUkhTuxFw6ssq4OtFSFUmXiU1wDEfEGJgGXAYeAdSIy2xizLV/Tb40x9+fblgbcYozZLSINgPUiMt8Yc8r2/OPGmO/LeA6qvPj4QY9b4Y83IHkP1G7h6ogutGUmINBplKsjUarKc+QKoRcQZ4yJN8ZkATOAEY4c3Bizyxiz2/b7EeAYoOsZViU9xoOXN6z71NWRXMgYq7Jps4sgtLGro1GqynMkITQEDtr9fci2Lb9rbd1C34vIBf86RaQX4Afssdv8qm2fd0TEv6AXF5EJIhItItFJSUkOhKucqnp9aD8CNn4FWWddHc35Dq6Fk3t17oFSTuJIQiioYzZ/5bNfgKbGmM7AIuC8ovoiUh/4ErjVGHNuyMpTQFugJ1ALeKKgFzfGTDbGRBpjIuvU0YsLl+g1wVorYcu3ro7kfFtmWOtBtx/u6kiUcguOJIRDgP03/kbAEfsGxphkY0ym7c9PgB7nnhOR6sBvwLPGmNV2+xw1lkzgc6yuKVUZNe4N4Z2tmcuVpQpqTibE/ADtrgL/EFdHo5RbcCQhrANaiUgzEfEDRgOz7RvYrgDOGQ5st233A2YB04wx3xW0j4gIMBKIKe1JqHImYl0lHNsG+/50dTSWXfOsWdQ690Appyk2IRhjcoD7gflYH/QzjTGxIvKSiJy7Vn/QNrR0M/AgMN62fRQwEBhfwPDSr0VkK7AVCANecdpZKefrdJ1VNG7tZFdHYtn8LVQLh+aDXB2JUm6j2GGnAMaYOcCcfNues/v9Kax7Avn3+wr4qpBjDi5RpMq1fAOh+y2wciKcPgQ1GrkulrPJsHs+9LnHGgGllHIKnamsHBd5O2Ag+jPXxhHzA+TlWOsmK6WcRhOCclzNJtD6Clj/BWRnuC6Ozd9AeCeo18F1MSjlhjQhqJLpPQHSkiF2lmteP2kXHNmgcw+UKgeaEFTJNLsYwtpY9Y1cMQR1ywwQL2u9BqWUU2lCUCUjYq2VcGQjHF5fsa+dl2eNLmoxBELqVexrK+UBNCGokusyGvxCYE0FV0Hd/yekHNK5B0qVE00IquT8Q6DrjdZ9hDPHyv/1sjOs4a4zb4GAGtDmyvJ/TaU8kCYEVTq97oS8bGvEUXnJy7WW8JwYCQuesRbAGT8H/ILK7zWV8mAOTUxT6gJhraDFYGtOwoBHwNvXecc2BnYvgEUvWOUy6neF4f+DFpc47zWUUhfQKwRVer3ugtSjsP0X5x3z4Dr44h8wfRRkp8N1n8OdSzQZKFUB9ApBlV6ryyC0iVUFteM1ZTtW0i5Y/CLs+BWC68KV/7EW53HmlYdSqkiaEFTpeXlb9xIWPAsJW63ZwyWVcgSWvg4bvwTfILjkGehzL/hXc368SqkiaUJQZdN1LPz+qlUFdfj/im+fkQKnDliPAyutq4u8XKv7aeBjEBxW/jErpQqkCUGVTVAt6DzKWuz+0hfBy+fvD/y/Hvv//j3j1Pn7dxoFlzwNtZq5Jn6l1F80Iaiy6zUBNkyFt9tDTvr5z/kEWkXxQiOgcS/r57lHzWZWQlFKVQqaEFTZhXeEwc9CylG7D3xbEggOs8pdKKUqPU0IyjkGPu7qCJRSZaTzEJRSSgEOJgQRiRKRnSISJyJPFvD8eBFJsls3+Q6758aJyG7bY5zd9h4istV2zPdFtF9BKaVcqdiEICLewCTgCqA9MEZE2hfQ9FtjTFfbY4pt31rA80BvoBfwvIjUtLX/EJgAtLI9osp6MkoppUrPkSuEXkCcMSbeGJMFzABGOHj8ocBCY8wJY8xJYCEQJSL1gerGmFXGGANMA0aWIn6llFJO4khCaAgctPv7kG1bfteKyBYR+V5EGhezb0Pb78UdUymlVAVxJCEU1Leff+3EX4CmxpjOwCJgajH7OnJM6wAiE0QkWkSik5KSHAhXKaVUaTiSEA4Bje3+bgQcsW9gjEk2xmTa/vwE6FHMvodsvxd6TLtjTzbGRBpjIuvUqeNAuEoppUrDkYSwDmglIs1ExA8YDcy2b2C7J3DOcGC77ff5wOUiUtN2M/lyYL4x5iiQKiJ9bKOLbgF+LuO5KKWUKoNiJ6YZY3JE5H6sD3dv4DNjTKyIvAREG2NmAw+KyHAgBzgBjLfte0JEXsZKKgAvGWNO2H6/B/gCCATm2h5FWr9+/XER2V+C87MXBhwv5b5VnSefO3j2+XvyuYNnn7/9uTdxZAexBvm4PxGJNsZEujoOV/DkcwfPPn9PPnfw7PMvzbnrTGWllFKAJgSllFI2npQQJrs6ABfy5HMHzz5/Tz538OzzL/G5e8w9BKWUUkXzpCsEpZRSRfCIhFBctVZ3JiL7bFVlN4lItKvjKW8i8pmIHBORGLtttURkoa3i7kK7AotupZBzf0FEDttVIr7SlTGWFxFpLCJLRGS7iMSKyEO27W7/3hdx7iV+792+y8hWrXUXcBnWDOl1wBhjzDaXBlZBRGQfEGmM8Yix2CIyEDgDTDPGdLRtexM4YYx53faFoKYx5glXxlkeCjn3F4Azxpj/uDK28mabHFvfGLNBREKA9VgFM8fj5u99Eec+ihK+955whVCWaq2qijHGLMOaHGlvBH/X15qKm1bWLeTcPYIx5qgxZoPt91SsagkN8YD3vohzLzFPSAiOVmt1VwZYICLrRWSCq4NxkXq2cinYftZ1cTwV7X5bJeLP3LHLJD8RaQp0A9bgYe99vnOHEr73npAQHK6s6qb6G2O6Yy1wdJ+tW0F5jg+BFkBX4CjwX9eGU75EpBrwA/CwMSbF1RhftdwAAAEvSURBVPFUpALOvcTvvSckhGKrtbozY8wR289jwCysLjRPk3iuAKPt5zEXx1NhjDGJxphcY0weViVit33/RcQX6wPxa2PMj7bNHvHeF3TupXnvPSEhFFut1V2JSLDtJhMiEoxVbTam6L3c0mzg3Hre4/Cgyrr5KhFfjZu+/7aqyZ8C240xb9s95fbvfWHnXpr33u1HGQHYhlu9y9/VWl91cUgVQkSaY10VgFXZdrq7n7uIfAMMwqr0mIi1pvdPwEwgAjgAXG9XdddtFHLug7C6DAywD7jrXJ+6OxGRAcByYCuQZ9v8NFZfulu/90Wc+xhK+N57REJQSilVPE/oMlJKKeUATQhKKaUATQhKKaVsNCEopZQCNCEopZSy0YSglFIK0ISglFLKRhOCUkopAP4fJWd2QqqFrK0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.plot(range(epochs), history.history['loss'])\n",
     "plt.plot(range(epochs), history.history['val_loss'])"

--- a/training/Sequence-to-Sequence Model in Keras.ipynb
+++ b/training/Sequence-to-Sequence Model in Keras.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -53,9 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%run -i \"../audio_preprocessing/generate_features.py\" -f mfcc -s 1 --local_download_dir \"../.audio\" --output_dir \"../.outputs\" "
@@ -63,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,19 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(100, 1067, 13)\n",
-      "(100, 40, 61)\n",
-      "(100, 40, 61)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "[print(a.shape) for a in [encoder_input_data, decoder_input_data, decoder_target_data]]\n",
     "\n",
@@ -232,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,67 +243,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train on 80 samples, validate on 20 samples\n",
-      "Epoch 1/25\n",
-      "80/80 [==============================] - 12s 144ms/step - loss: 3.5909 - val_loss: 2.4462\n",
-      "Epoch 2/25\n",
-      "80/80 [==============================] - 7s 93ms/step - loss: 3.5590 - val_loss: 2.4280\n",
-      "Epoch 3/25\n",
-      "80/80 [==============================] - 8s 97ms/step - loss: 3.5232 - val_loss: 2.4028\n",
-      "Epoch 4/25\n",
-      "80/80 [==============================] - 7s 94ms/step - loss: 3.4681 - val_loss: 2.3597\n",
-      "Epoch 5/25\n",
-      "80/80 [==============================] - 8s 98ms/step - loss: 3.3633 - val_loss: 2.2845\n",
-      "Epoch 6/25\n",
-      "80/80 [==============================] - 8s 99ms/step - loss: 3.2324 - val_loss: 2.2125\n",
-      "Epoch 7/25\n",
-      "80/80 [==============================] - 8s 97ms/step - loss: 3.1318 - val_loss: 2.1556\n",
-      "Epoch 8/25\n",
-      "80/80 [==============================] - 7s 93ms/step - loss: 3.0533 - val_loss: 2.1089\n",
-      "Epoch 9/25\n",
-      "80/80 [==============================] - 8s 99ms/step - loss: 2.9862 - val_loss: 2.0692\n",
-      "Epoch 10/25\n",
-      "80/80 [==============================] - 8s 97ms/step - loss: 2.9259 - val_loss: 2.0341\n",
-      "Epoch 11/25\n",
-      "80/80 [==============================] - 8s 96ms/step - loss: 2.8704 - val_loss: 2.0023\n",
-      "Epoch 12/25\n",
-      "80/80 [==============================] - 8s 96ms/step - loss: 2.8186 - val_loss: 1.9734\n",
-      "Epoch 13/25\n",
-      "80/80 [==============================] - 8s 94ms/step - loss: 2.7700 - val_loss: 1.9464\n",
-      "Epoch 14/25\n",
-      "80/80 [==============================] - 8s 96ms/step - loss: 2.7241 - val_loss: 1.9212\n",
-      "Epoch 15/25\n",
-      "80/80 [==============================] - 8s 100ms/step - loss: 2.6810 - val_loss: 1.8980\n",
-      "Epoch 16/25\n",
-      "80/80 [==============================] - 8s 97ms/step - loss: 2.6404 - val_loss: 1.8767\n",
-      "Epoch 17/25\n",
-      "80/80 [==============================] - 8s 96ms/step - loss: 2.6030 - val_loss: 1.8578\n",
-      "Epoch 18/25\n",
-      "80/80 [==============================] - 8s 100ms/step - loss: 2.5681 - val_loss: 1.8412\n",
-      "Epoch 19/25\n",
-      "80/80 [==============================] - 7s 92ms/step - loss: 2.5364 - val_loss: 1.8264\n",
-      "Epoch 20/25\n",
-      "80/80 [==============================] - 7s 93ms/step - loss: 2.5080 - val_loss: 1.8140\n",
-      "Epoch 21/25\n",
-      "80/80 [==============================] - 7s 86ms/step - loss: 2.4827 - val_loss: 1.8044\n",
-      "Epoch 22/25\n",
-      "80/80 [==============================] - 8s 97ms/step - loss: 2.4607 - val_loss: 1.7967\n",
-      "Epoch 23/25\n",
-      "80/80 [==============================] - 7s 93ms/step - loss: 2.4421 - val_loss: 1.7899\n",
-      "Epoch 24/25\n",
-      "80/80 [==============================] - 8s 100ms/step - loss: 2.4262 - val_loss: 1.7863\n",
-      "Epoch 25/25\n",
-      "80/80 [==============================] - 8s 95ms/step - loss: 2.4128 - val_loss: 1.7812\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "history = model.fit([encoder_input_data, decoder_input_data], decoder_target_data,\n",
     "              batch_size=batch_size,\n",
@@ -334,32 +255,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x23bb06c6e80>]"
-      ]
-     },
-     "execution_count": 115,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAD8CAYAAABw1c+bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvDW2N/gAAIABJREFUeJzt3Xl8VdW5//HPkzlkhAwQMhAmEQUFjTigqDgUnKd6HavWlvZebaud7r29/d3Od2qvrbWT1PlWrYpTnUVFQa1IwgxhnhKmBDJAIIEM6/fHOkCIAU4w5Jyc832/XvuVc/ZZJ3k258Xz7LP22muZcw4REYkeMaEOQEREepYSv4hIlFHiFxGJMkr8IiJRRolfRCTKKPGLiEQZJX4RkSijxC8iEmWU+EVEokxcqAPoTHZ2tisuLg51GCIivUZZWdk251xOMG3DMvEXFxdTWloa6jBERHoNM1sfbFt19YiIRBklfhGRKKPELyISZZT4RUSijBK/iEiUUeIXEYkySvwiIlEmshL/B/8Di6bBru2hjkREJGyF5Q1cR6W5ET75IzTWAAYDx8DQiTD0Aig4DeISQh2hiEhYsHBcbL2kpMQd1Z27ba2waR6sehdWvweVc8C1QkIqFJ8Dwy7wxaDfEDDr/sBFRELEzMqccyXBtI2cM36AmFgoKPHbef8MTfWwdqYvAqvehRVv+HaZRf6bwNCJMHgCJGeGNm4RkR4UWYm/o6QMGHm53wC2r/ZFYPUMfy2g7FGwWBh0Fhx/KYy4BPoOCm3MIiLHWGR19XRFa7PvClo5HZa/AdXlfn//UTBisi8CA8eqS0hEeoWudPVEb+LvaPtqXwCWvw4b/g6uDdIG+iJw/CVQPEEXiEUkbCnxf167tsPKt2DZa75rqHk3JKTB8AthxKUw/CJdFxCRsNKtF3fNLAmYCSQG2k9zzv2oQ5vbgV8CGwO7fueceyjw2m3ADwP7f+6cezyYwEIqJQvG3OS35kZY8wEsfw2WvwlLXoT4PnDqHXDW3ZA+MNTRioh0yRHP+M3MgBTnXIOZxQMfAt9yzn3Srs3tQIlz7u4O7+0HlAIlgAPKgFOdc7WH+5shP+M/lLY22FgKcx6GRc+BxcCYG2H8PZA1NNTRiUgU68oZ/xHv3HVeQ+BpfGALtn/oC8B051xNINlPByYF+d7wExMDhePgmgfhm/Pg1NtgwTPwuxJ47g7YvDDUEYqIHFFQUzaYWayZzQeq8Il8difNrjWzhWY2zcwKA/vygYp2bSoD+zr7G1PMrNTMSqurq7twCCHSdxBc+r9wzyI465t+dNCD58CTX4T1fw91dCIihxRU4nfOtTrnxgAFwDgzG9WhyStAsXPuJOAdYF8/fmdjITv9tuCcm+qcK3HOleTkBLVecHhI6w8X/QTuXQwTfwgby+DRSfDIZF8MwvDiuYhEty5N0uacqwPep0N3jXNuu3NuT+Dpn4FTA48rgcJ2TQuATUcVabhLzoQJ34N7FsOk/4a6DfDkdf5bwOIX/HQSIiJh4IiJ38xyzCwz8DgZuBBY1qFNXrunVwCBu6F4C7jYzPqaWV/g4sC+yJXQB874ur8GcOXvobkJpt0Bf7kG9uwMdXQiIkGd8ecBM8xsITAH38f/qpn91MyuCLT5ppktMbMFwDeB2wGcczXAzwLvmwP8NLAv8sUlwNhb4K7ZcNmvYe0seOxSaKgKdWQiEuV0A1dPWTkdnv0SpPaHW1/wM4SKiHSTbh3OKd1k+EVw2yt+xtCHL4ZN80MdkYhEKSX+nlRQAne+DXFJvttn9YxQRyQiUUiJv6dlD4c7p0PmID/mf9G0UEckIlFGiT8U0vPgjtf9XcDP3+mXjBQR6SFK/KGSnAm3vOAXiXnzX2D6j3Szl4j0CCX+UIpPgi8+DiVfho9+Ay/9k18gRkTkGIrspRd7g5hYuPQ+SB0A7/8H7N4GX3wMElJCHZmIRCid8YcDM784/GW/gVXvwONX+MVgRESOASX+cFJyB1z/f7BlETzyBdixOdQRiUgEUuIPNyMvgy+9BDs3+0nemupDHZGIRBgl/nA06Cy4/gmoXgbP3Aote0MdkYhEECX+cDXsArjiAVj7Abx8l1/2UUSkG2hUTzgbcxPs2ATv/cwv6n7RT0IdkYhEACX+cHfOd2DHRj/OP6MAxn011BGJSC+nxB/uzOCSX8HOLfD69yBtgL/bV0TkKKmPvzeIiYVrH/azez7/FdjwSagjEpFeTIm/t0joAzc+A+n58NQ/QPWKUEckIr2UEn9vkpIFtzwPsfHwl2t994+ISBcFs9h6kpl9amYLAuvqfmZoiZl928yWmtlCM3vXzAa1e63VzOYHtr919wFEnX6D4ebnYPd2P5+/FnAXkS4K5ox/DzDROXcyMAaYZGZndGgzDyhxzp0ETAP+p91rjc65MYHtCuTzGzgWrn8cti7x6/hqRk8R6YIjJn7nNQSexgc216HNDOfc7sDTT4CCbo1SPmv4RXDFb2H1e/C3b2gufxEJWlB9/GYWa2bzgSpgunNu9mGa3wm80e55kpmVmtknZnbVYf7GlEC70urq6qCCj3pjb4HzfgALnob3fh7qaESklwhqHL9zrhUYY2aZwItmNso5t7hjOzO7BSgBzm23u8g5t8nMhgDvmdki59zqTv7GVGAqQElJiU5fg3Xu9/0NXrN+5Zd0PO0roY5IRMJcl0b1OOfqgPeBSR1fM7MLgX8DrnDO7Wn3nk2Bn2sC7x179OHKZ5j5hVyGfwFe+w58+Gt1+4jIYQUzqicncKaPmSUDFwLLOrQZCzyIT/pV7fb3NbPEwONsYDywtPvCFwBi4/xsnqOuhXd+DK98Sxd8ReSQgunqyQMeN7NYfKF41jn3qpn9FCh1zv0N+CWQCjxnZgAbAiN4RgIPmllb4L3/5ZxT4j8W4pPgmoegbzHM+l+or/RLOCalhzoyEQkz5sKwW6CkpMSVlpaGOozeq+xxePVeyB0JNz0LGfmhjkhEjjEzK3POlQTTVnfuRqJTb/M3edWuh4cugM0LQx2RiIQRJf5INewCuPMtsBh4dDKsnB7qiEQkTCjxR7L+J8JX3oV+Q/zEbqWPhDoiEQkDSvyRLj0P7njDfwN49V6Y/u9axlEkyinxR4PEVLjhaSi5Ez66H6bdAc2NoY5KREJEK3BFi9g4uPR//eyeb/8Qdm72xSAlK9SRiUgP0xl/NDGDs74BX3wcNi/wI362rQx1VCLSw5T4o9GJV8Ftr/q5/P90Dsyeqn5/kSiixB+tCk+Dr8+C4rPhje/BE1f4cf8iEvGU+KNZ+kB/o9cVD8Cm+fDHs6DsMU3yJhLhlPijnRmc8iX4p48h/xQ/wduT10H9xlBHJiLHiBK/eJlFcOvLcMmvYP3H8IczYf7TOvsXiUBK/HJATAyM+yp8/UPofwK89HX4682wc2uoIxORbqTEL5+VNRRufw0u/gWsegf+cAYsfiHUUYlIN1Hil87FxMJZd/uz/36D/d2+z90Ou7aHOjIR+ZyU+OXwco6DL78NE/8flL8KfzgdFjyjcf8ivZgSvxxZbBxM+C587QPIKIQXp8AjF0NlWagjE5GjoMQvwds3zfNVf4S6DfDQRHjxH2HnllBHJiJdEMxi60lm9qmZLTCzJWb2k07aJJrZM2a2ysxmm1lxu9f+NbB/uZl9oXvDlx4XEwNjboJvlMHZ98LiafDAqTDrPmhuCnV0IhKEYM749wATnXMnA2OASWZ2Roc2dwK1zrlhwK+B/wYwsxOAG4ATgUnAHwKLtktvl5gGF/4Y7poNg8+Fd3/i+//LX9XYf5Ewd8TE77yGwNP4wNbxf/aVwOOBx9OAC8zMAvv/6pzb45xbC6wCxnVL5BIe+g2BG5+CW1+EuCR45mZ44krYujTUkYnIIQTVx29msWY2H6gCpjvnZndokg9UADjnWoB6IKv9/oDKwD6JNEMnwtc/gsm/9FM+/2k8vPZd2F0T6shEpIOgEr9zrtU5NwYoAMaZ2agOTayztx1m/2eY2RQzKzWz0urq6mDCknATGwenT4FvzvOrfZU+DA+cArMfhJa9oY5ORAK6NKrHOVcHvI/vr2+vEigEMLM4IAOoab8/oADYdIjfPdU5V+KcK8nJyelKWBJu+vSDS3/lb/4aMBre+L6/ADzvL9DaEuroRKJeMKN6cswsM/A4GbgQWNah2d+A2wKPrwPec865wP4bAqN+BgPDgU+7K3gJc/1PhC/9DW5+3heDl+8KTP/wvG4AEwmhYM7484AZZrYQmIPv43/VzH5qZlcE2jwMZJnZKuDbwL8AOOeWAM8CS4E3gbucc63dfRASxsxg+IUw5X34h79ATBxM+zI8OAGWv6ERQCIhYC4M/+OVlJS40tLSUIchx0Jbqz/jn/EfULsWCk6DiT+EIeeFOjKRXs3MypxzJcG01Z270rNiYuGk6+HuOXD5/bBjkx/++dhlUKFeQJGeoMQvoREbD6feDt+YC5P+C6qXwcMXwZPX++GgInLMKPFLaMUnwRn/CN+cDxf8O1R84vv//3ozbJoX6uhEIpISv4SHxFQ45zvwrYUw4fuwdhZMPQ/+7xpY91GooxOJKEr8El6SM2Hiv8G9i+CCH/lun8cugUcmwcrpGgUk0g2U+CU8JWXAOd+GexbB5P+Bugp48jrfDbTkJT86SESOihK/hLeEPnD61/w0EFf+Hpp3w3O3we9Ph3lPQmtzqCMU6XWU+KV3iEuAsbfAXZ/CdY/6mUBf/if47Vj49M/Q3BjqCEV6DSV+6V1iYmHUNfD1WXDTc5A+EF7/LvzmJJj5S80GKhIEJX7pnczguIvhy2/B7a9D3knw3s/hvhPg1W/DtlWhjlAkbMWFOgCRz8UMisf7raoc/v57Pwto6SNw3CQ4624YNN63ExFAZ/wSSXJHwpW/g3sXw7n/DJWfwmOXwtRzYeGzuhAsEqDEL5EnNRfO/1e4d4mfD6i5EV74qr8O8OFvoLE21BGKhJQSv0Su+GQ/H9A/zYabp0HOcfDOj+C+E+H170PNmlBHKBIS6uOXyBcTA8Mv8tuWRfD3P/hrAJ9OheEXw7ivwtALfDuRKKD5+CU67dgMZY9C2WPQsBX6DobT7oQxN/vVwkR6ma7Mx6/EL9GtZS8sewU+fQg2fOxvDBt9HZz2VRg4JtTRiQStK4lfXT0S3eISYNS1ftuyGOY8BAuf8UNCC07zBeDEqyAuMdSRinSbI57xm1kh8AQwAGgDpjrn7u/Q5nvAzYGnccBIIMc5V2Nm64CdQCvQEkxF0hm/hFRTPcx/Gub8Gbavgj7ZcMqXoOTLkFkY6uhEOtWtXT1mlgfkOefmmlkaUAZc5Zxbeoj2lwP3OucmBp6vA0qcc9uCPQAlfgkLbW2w9n3fDbTiDb/vuElwym0w7EKI1RdmCR/d2tXjnNsMbA483mlm5UA+0GniB24Eng4yVpHwFRMDQyf6ra7CjwSa9xdY/jqkDfSTxp1yK2QWhTpSkS7p0sVdMysGZgKjnHM7Onm9D1AJDHPO1QT2rQVqAQc86JybeqS/ozN+CVutzbDiTSh7HFa94/cNu8B/Cxgx2a8lLBICx+TirpmlAs8D93SW9AMuBz7al/QDxjvnNplZLjDdzJY552Z28vunAFMAiop0BiVhKjYeRl7ut7oN/hvAvL/As7dCSi6MuclfD8gaGupIRQ4pqDN+M4sHXgXecs7dd5h2LwLPOeeeOsTrPwYanHO/Otzf0xm/9Cptrf7sv+wxWPEWuFYYPMF/Cxh5uUYESY/o1jN+MzPgYaD8CEk/AzgXuKXdvhQgJnBtIAW4GPhpMIGJ9BoxsXDcF/y2YzPM/wvMfQKevxOS+8FJ18PJN0LeyZolVMJCMKN6zgZmAYvwwzkBfgAUATjn/hRodzswyTl3Q7v3DgFeDDyNA55yzv3iSEHpjF96vX0jgsoe9xeDW/dC7gm+AJx0PaQNCHWEEmF0565IOGmshcUvwIKnoXIOWIyfG2jMTTDiEohPCnWEEgGU+EXC1baVMP8pf3fwjo2QlAEnXuOLQMFp6gqSo6bELxLu2lph7UxfBMpfgZZGyBoGJ98AJ92gO4Sly5T4RXqTph2w9GXfFbT+I7+v6Cw/WdwJV0FKVmjjk15BiV+kt6pZC4ue89u2FRAT5+8cHnUdHH8JJKaFOkIJU0r8Ir2dc37RmMXT/IXh+gqIS4YRk2D0F/1cQbo/QNpR4heJJG1tUDHbF4ElL8Lu7f6i8MgrfHdQ8Tn+XgKJakr8IpGqtRnWfOCLQPkrsLcBUvv7awEnXAFFZ6oIRCklfpFo0Nzop4hY9JyfMqKlya8dcPylvggUT/ALzUhU0ApcItEgPtmvDnbiVbCnAVZN998CFj8Pcx/33UHHTfZFYOhE314EJX6RyJCYCide7bfmJlgzwxeBZa/Bwr9CfAoMv8gXgeEXa3RQlFPiF4k08Ul+bYARk/01gXWzfBEofxWWvgSxif4bwPGXwPAvQFr/UEcsPUx9/CLRoq0VKj6F8r/5QlBf4ffnn+q7hI77AgwYrWkjeild3BWRw3MOti7xawkvfxM2lgEO0gt8ARgx2Q8T1QRyvYYSv4h0TUMVrHwblr8Bq2dA8y6I7wNDzvc3jalLKOxpVI+IdE1qrl88fuwt/uLwug8PfBtY/ppvM/AUv77w0Il+JlGtL9xr6YxfRA6tfZfQirdhYym4NkhIg8Hn+CIwdCL0G6JrAyGmM34R6R5mMGCU3yZ8Dxrr/Cih1e/Bqnf96mIAmYMOFIHBEyA5M7Rxy2Ep8YtI8JIz/QLyIy/3z2vW+CKwegYsmgZlj/oVxvJLfBEYcq4fNaQJ5cKKunpEpHu0NvvRQavf89vGMt8tFJfkrwkMOgsGjfePE/qEOtqI062jesysEHgCGIBfbH2qc+7+Dm3OA14G1gZ2veCc+2ngtUnA/UAs8JBz7r+OFJQSv0gEaKyF9R/7bd2HsGWhLwQx8ZB/ii8Cg8ZD0em6k7gbdHfizwPynHNzzSwNKAOucs4tbdfmPOC7zrnLOrw3FlgBXARUAnOAG9u/tzNK/CIRqKne30C27kNfDDbNhbYW3zWUd/KBQlB4ulYdOwrdenHXObcZ2Bx4vNPMyoF84LDJO2AcsMo5tyYQ2F+BK4N8r4hEkqQMP1/Q8Iv88727fCFY/7FfcvLTP8Pff+df6zfEdwkVnOavEQwYreGj3ahLF3fNrBgYC8zu5OUzzWwBsAl/9r8EXyAq2rWpBE4/xO+eAkwBKCoq6kpYItIbJaTA0PP9Bv7+gY1lUDnHb2veh4XP+NfikiBvDBSUHCgIGfkhC723Czrxm1kq8Dxwj3NuR4eX5wKDnHMNZnYJ8BIwHOhsYG+nfUvOuanAVPBdPcHGJSIRIj4Jisf7Dfw9BPWV/t6BylJfDNp/K0jL84Ugv8R3FQ04SV1EQQoq8ZtZPD7pP+mce6Hj6+0LgXPudTP7g5ll48/wC9s1LcB/IxAROTwzyCz024lX+30te2HrIqhs982g/JUD70nP991CA0b7QjBgNPQt1s1lHRwx8ZuZAQ8D5c65+w7RZgCw1TnnzGwcEANsB+qA4WY2GNgI3ADc1F3Bi0iUiUvwff75p8LpU/y+3TV+xNCWRbA58HPl234EEUBiertiENhyjo/qewuCOeMfD9wKLDKz+YF9PwCKAJxzfwKuA/7RzFqARuAG54cLtZjZ3cBb+OGcjwT6/kVEukeffjDkPL/t09wIVUsPLgZzn4Dm3f51i4V+gyF7BOQEtuzj/JaY2vPH0MMi6gauBz9YTVZqIkNzUhiam0p6kkYBiEhAW6u/03jzAqgqh+plsG2F39fWcqBdesHBxSBnhC8QYX79ICrn6mlpbePX76ygqblt/77ctESG5qQyLDd1fzEYlpvKgPQkTH1+ItElJhayh/utvdZmn/yrl8O25f5n9XI/zLSl8UC7pEz/LaHv4M/+TMuDmJiePZ7PIaLO+Jtb29hQs5vVVQ2srt7F6uoGVlU1sLq6gZ1NByp6SkIsQwIFYVhuKqPzMzi5MJOMZH1DEJGAtja/Stm2Fb4Q1KyGmrVQuw7qNoBrPdA2LslPVHdQQSiGjEI/7DQp45iHq4VYOnDOUd2wh9VVBxeDNdW72Fh3oKIPzUlhTGFfxhZlMqYwk+MHpBEX23uquIj0kNYWXxRq1waKwdoDRaFmrV/Ipr3EdD/iKKPAF4KMAt+ltO95ev7nvtisxN8FO5qaWVRZz7wNtcyvqGPehjq279oLQFJ8DCflZzImUAjGFmWSl5HcI3GJSC/lHOyq9kWgvgLqN/r7EXZsPPB897bPvi8l119TuOO1o/qzUdnHf7TSk+IZPyyb8cOyAf/toLK2kbmBQjC/oo7HPlrH3lZ/7aB/eiJnDMniqrH5nDMsW98IRORgZn5Fs9RcKBzXeZvmRtix6UAh2FcUXFvn7bs7xGg/4w/GnpZWyjfvZN6GWuZtqGPmymrqdjeTk5bI1WPzufaUAkYM0OyCIhI66uo5xva0tDJjWRXTyjby/vIqWtoco/LTufaUAq44eSBZqdF7Y4iIhIYSfw/a3rCHl+dv4vm5lSzZtIO4GOP843O59pQCJh6fS0KcuoJE5NhT4g+RZVt28MLcjbw4byPVO/fQt088V5w8kGtPLWB0fobuHRCRY0aJP8RaWtuYtWobz5dV8vbSrextaWP8sCz+8+qTKMrSknMi0v2U+MNIfWMzz5dV8uvpK2hua+O7F4/gjvGDiY3R2b+IdJ+uJH51QB9jGcnxfPnswbz97QmMH5rNz18r55o/fszyLTtDHZqIRCkl/h6Sl5HMQ7eV8Nsbx1JRs5vLHpjFr6evYG9Lz4zbFRHZR4m/B5kZV5w8kHe+fS6Xjs7j/ndXctkDs5i3oTbUoYlIFFHiD4F+KQn85oaxPHr7aexsauGaP37Mz15dyu69LUd+s4jI56TEH0LnH5/L2/dO4ObTi3j4w7V84Tcz+WhVJ3N4iIh0IyX+EEtLiufnV43mmSlnEBcTw80Pzeafpy2kvrE51KGJSIRS4g8Tpw/J4o1vncPXzx3KtLmVXHTfB7y2cDPhONxWRHq3IyZ+Mys0sxlmVm5mS8zsW520udnMFga2j83s5HavrTOzRWY238wiY3D+MZIUH8u/TD6el+8aT05aInc9NZc7HpvDhu27Qx2aiESQYM74W4DvOOdGAmcAd5nZCR3arAXOdc6dBPwMmNrh9fOdc2OCvbkg2o3Kz+Dlu8bz75edwJy1NVz06w/4/YxVGvopIt3iiInfObfZOTc38HgnUA7kd2jzsXNu35jET4CC7g402sTFxvDlswfzznfO5fwRufzyreVc+ttZfLq2JtShiUgv16U+fjMrBsYCsw/T7E7gjXbPHfC2mZWZ2ZSuBhjt8jKS+dOtp/LwbSXs3tvK9Q/+ne9PW0BtYJUwEZGuCnoFLjNLBZ4H7nHO7ThEm/Pxif/sdrvHO+c2mVkuMN3MljnnZnby3inAFICioqIuHEJ0uGBkf84cmsX9767k4Vlrmb50Kz+4ZCTXnVqgWT9FpEuCmqTNzOKBV4G3nHP3HaLNScCLwGTn3IpDtPkx0OCc+9Xh/l4kTdJ2LCzbsoN/e3ExZetrOX1wP35x9SiG5WoFMJFo1q2TtJk/nXwYKD9M0i8CXgBubZ/0zSzFzNL2PQYuBhYHE5gc2vED0nnua2fyn9eMZtmWnUy+fxa/ems5Tc2toQ5NRHqBI57xm9nZwCxgEbBvWMkPgCIA59yfzOwh4FpgfeD1FudciZkNwX8LAN+t9JRz7hdHCkpn/MHb1rCH/3itnBfmbSQ/M5m7Jw7j2lMKtPKXSJTRfPxR6ONV2/jvN5exoLKegRlJ/ON5Q/liSSFJ8bGhDk1EeoASf5RyzjFz5TZ+++5KytbX0j89ka9NGMqN44pITlABEIlkSvxRzjnH31dv5/53VzJ7bQ3ZqYlMmTCYW84YRJ+EoAdyiUgvosQv+81es50H3lvFh6u20S8lga+cM5gvnVlMaqIKgEgkUeKXzyhbX8sD763k/eXVZCTHc+fZg7ntrGIykuNDHZqIdAMlfjmkBRV1PPDeKt4p30paYhw3nV7EjeOKKM5OCXVoIvI5KPHLES3ZVM8fZqzmzSVbaG1zjB+WxU3jBnHRCf01FFSkF1Lil6Bt3dHEs3Mq+OucCjbWNZKdmsAXSwq58bQiirL6hDo8EQmSEr90WWubY+bKap6avYF3y7fS5uCc4dncNK6IC0/oT3ysvgWIhDMlfvlcttQ38cycCp6Zs4FN9U3kpCVyfUkBN5xWRGE/fQsQCUdK/NItWtsc7y+v4qnZG5ixvAoHTBiew9Vj87nwhP4aEioSRpT4pdttqmvkmTkVPFdawab6JhLjYrhgZC6XnTSQicfnamoIkRBT4pdjpq3NUbahllcXbOK1RZvZ1rCXlIRYLjqhP5efPJBzhudoVJBICCjxS49oaW1j9toaXl24iTcWb6FudzPpSXFMGjWAy08eyJlDsojTRWGRHqHELz1ub0sbH63axisLN/H2kq007GkhKyWByaMHcOnogZxW3FdFQOQYUuKXkGpqbuX95dW8snAT75Zvpam5jYzkeM4fkcMFI/tz7ogc0pM0VYRId+pK4tewDOl2SfGxTBo1gEmjBrBrTwszV1TzTnkV7y3bykvzNxEXY5w+pB8XjuzPhSP7a4ioSA/TGb/0mNY2x7wNtUwv38q75VWsqmoAYET/NC4YmcsFI/szpjCT2BgtHi/SVerqkV5h3bZdvBMoAp+uq6G1zZGdmsD5I3KZeHwuZw3NJqOPuoREgtGtid/MCoEngAH4NXenOufu79DGgPuBS4DdwO3OubmB124Dfhho+nPn3ONHCkqJP/rU727m/RVVvFtexYzlVexsaiHG4OTCTM4ZnsOE4dmMKczUBWKRQ+juxJ8H5Dnn5ppZGlAGXOWcW9quzSXAN/CJ/3Tgfufc6WbWDygFSgAXeO+pzrnaw/1NJf7o1tzaxoKKOmau3MasldUsqKijzUFaYhxnDs3inON8IRiUpamkRfbp1ou7zrnNwObA451mVg7kA0vbNbsSeML5KvKJmWUGCsZ5wHTnXE0gsOnAJODpLhyPRJn42BhKivvfybkyAAALV0lEQVRRUtyPb190HPW7m/l49TZmrtzGzBXVvL10KwBF/fpwzvBsJhyXw5lDszRSSCRIXRrVY2bFwFhgdoeX8oGKds8rA/sOtV8kaBl94pk8Oo/Jo/NwzrFu+25mraxm5optvDRvI0/O3kBsjDEqP4MzhvTjjCFZlAzqS5oKgUingk78ZpYKPA/c45zb0fHlTt7iDrO/s98/BZgCUFRUFGxYEmXMjMHZKQzOTuFLZxbT3NrGvA11zFpZzew1NTzy4Voe/GANMQaj8zM4Y0iWLwTFKgQi+wSV+M0sHp/0n3TOvdBJk0qgsN3zAmBTYP95Hfa/39nfcM5NBaaC7+MPJi6R+NgYxg3ux7jB/QBo3NvKvA21fLJmO5+sqeHRj9bx4ExfCEbtLwS+G0ldQxKtgrm4a8DjQI1z7p5DtLkUuJsDF3d/65wbF7i4WwacEmg6F39xt+Zwf1MXd6W7NDW3MndDLZ+sqeGTNduZv6GOva1txBicODCDkuK+lAzqx2nFfclNTwp1uCJHrbvv3B0P3AosMrP5gX0/AIoAnHN/Al7HJ/1V+OGcdwReqzGznwFzAu/76ZGSvkh3SoqP5ayh2Zw1NBs4UAhmr6lh9trtPP3pBh79aB3gLxaXDOobuLDcl2E5qcToZjKJQLqBS6Jac2sbSzbtoHRdDaXraildX8O2hr0AZCTHUzKoL6cW9+W04n6Mzs/QugMStjRXj0iQ4mNjGFOYyZjCTL5yDjjnWL99N3PaFYJ3l1UBkBAbw4n56Ywt7MuYokzGFmZS0DcZ3xsq0nvojF/kCLY37KFsfS2l62uZt6GWhZX17GlpAyA7NYExhX0ZGygEJxVmaklKCQmd8Yt0o6zURC4+cQAXnzgA8N1Dy7fsZN6GWuZV1DF/Qx3vlPubyszguNw0xhRmMrYokzFFmQzLSdVUExJWdMYv0g3qdu9lQWU98zbUMr+ijnkb6qhvbAYgKT6GEwdmMDo/g1H5/ufQnBQVA+lWmp1TJMT23WE8b0MtizbWs3hjPUs27WD33lbAF4MT8tIZnZ/B6IJMFQP53JT4RcJQa5tj7bYGFm2sZ2Hl4YvByLx0RualM2JAmkYSSVDUxy8ShmJjjGG5aQzLTePqsQXAwcVgUeUOFm+sZ1pZJbsCxSDGYHB2yv5CcELgZ//0RI0mkqOmxC8SQgcXA7+vrc1RUbub8s07WLp5J+WbdzC/oo5XF27e/76+feL3F4OReekcPyCNoTmpJCfo24EcmRK/SJiJiTEGZaUwKCuFSaPy9u/f0dTMskAh2Lc9OXs9Tc1+aKkZ5GcmMzw3lWG5qQzPTWNYf/9Y8xJJe0r8Ir1EelL8QRPSwb6uol2s3LqTlVUNrKpqYGVVAx+t3s7ewL0GAP3TEw8Ug0BhGJKdQk6auoyikRK/SC/mu4p8Ip/cbn9rm6OydjcrtzbsLwirqnbyXGnF/usHACkJsQzKSqE4uw/FWSkUB6a8HpTVh5xUFYVIpcQvEoFi23UXXXhC//37nXNsrm9iZVUD67btYu22XazbvovyzTt5e8lWWtoOjPJLTYxjUNa+gtCHQVkpFPbtQ2G/ZPIykonVBHa9lhK/SBQxMwZmJjMwM5lzj8s56LXm1jY21jaydvsu1m/bxbrtu1m7bRdLNtXz5pIttLYrCnExRl5mki8EfftQ0DeZwn6+KBT27UN2aqJmNg1jSvwiAvgJ64qzfXcPIw5+bV9RqKxtpKJ2NxU1u/c/fm95FdU79xzUPiEuhoK+yeRnJjMgPYkBGUn0T0/a/3hARhL9+iSoOISIEr+IHNFBRaETjXtb2Vi3m4raRipr/M+Kmt1sqm9i5dZtVO1sos11/J1GblqgEKQHCkNGIjlpifRLSSQrJYF+gU03sXUvJX4R+dySE2L334/QmZbWNrY17GXLjia21DexdUcTW3Y0sbW+ic31TZRv3sGM5VX772LuKDUxbn8RyE7dVxAOFIeM5Hgy+sT7n4FNxeLQlPhF5JiLi43Z38Vz0Orc7Tjn2Lmnhe0Ne9nesIftu/ZSE9i2NezZ/3hjXROLNtZTs2svza2HnnImIS7moELQfktPiiMtKZ60g376x/teS4qPidhRTUr8IhIWzIz0pHjSk+IZfIgupfb2FYqahr3UNzZ/ZtvR4fnWHU2s2LqT+sZmdja1HPH3x8XYQYWhT0IsiXGxJMbFkBgfc+BxXAyJ8e0ex8UGXo8hOSGOPvGx9EmIJTkhlj4J/vf0CTwOVXFR4heRXql9oeiqtjZHw94Wdja1sLOp+aCfOwKPG5oOfr2xuZXG5lbqGveyp7mNPS1t7Glp9T+b22hqaaWrc16aQXK7wpCXnsyzXz+zy8fTVUdM/Gb2CHAZUOWcG9XJ698Dbm73+0YCOYGF1tcBO4FWoCXYmeNERI6lmJj2RSO5W36nc47mVre/GDQ1t9K4t5Xdga2xueXA4/0/W9jV7nFPXZcI5oz/MeB3wBOdveic+yXwSwAzuxy41zlX067J+c65bZ8zThGRsGZmJMQZCXExdH6JO3wccdUH59xMoOZI7QJuBJ7+XBGJiMgx1W3L/ZhZH2AS8Hy73Q5428zKzGzKEd4/xcxKzay0urq6u8ISEZEOunOdt8uBjzp084x3zp0CTAbuMrMJh3qzc26qc67EOVeSk5NzqGYiIvI5dWfiv4EO3TzOuU2Bn1XAi8C4bvx7IiJyFLol8ZtZBnAu8HK7fSlmlrbvMXAxsLg7/p6IiBy9YIZzPg2cB2SbWSXwIyAewDn3p0Czq4G3nXO72r21P/Bi4OaEOOAp59yb3Re6iIgcjSMmfufcjUG0eQw/7LP9vjXAyUcbmIiIHBvd2ccvIiK9gLmu3mPcA8ysGlh/lG/PBqL1hrFoPnaI7uPXsUevfcc/yDkX1JDIsEz8n4eZlUbr1BDRfOwQ3cevY4/OY4ejO3519YiIRBklfhGRKBOJiX9qqAMIoWg+doju49exR68uH3/E9fGLiMjhReIZv4iIHEbEJH4zm2Rmy81slZn9S6jj6Wlmts7MFpnZfDMrDXU8x5KZPWJmVWa2uN2+fmY23cxWBn72DWWMx9Ihjv/HZrYx8PnPN7NLQhnjsWJmhWY2w8zKzWyJmX0rsD/iP//DHHuXP/uI6Ooxs1hgBXARUAnMAW50zi0NaWA9KLDaWUk0LHoTmOW1AXhi36pwZvY/QI1z7r8Chb+vc+6fQxnnsXKI4/8x0OCc+1UoYzvWzCwPyHPOzQ3MBVYGXAXcToR//oc59uvp4mcfKWf844BVzrk1zrm9wF+BK0Mckxwjh1gc6Erg8cDjx/H/ISJSFxdHiijOuc3OubmBxzuBciCfKPj8D3PsXRYpiT8fqGj3vJKj/AfpxYJe9CZC9XfObQb/HwTIDXE8oXC3mS0MdAVFXFdHR2ZWDIwFZhNln3+HY4cufvaRkvitk329vw+ra4Je9EYi0h+BocAYYDPwv6EN59gys1T8an/3OOd2hDqentTJsXf5s4+UxF8JFLZ7XgBsClEsIaFFb9ga6APd1xdaFeJ4epRzbqtzrtU51wb8mQj+/M0sHp/4nnTOvRDYHRWff2fHfjSffaQk/jnAcDMbbGYJ+NXA/hbimHqMFr0B/Od9W+DxbbRbFCga7Et6AVcToZ+/+QU+HgbKnXP3tXsp4j//Qx370Xz2ETGqByAwhOk3QCzwiHPuFyEOqceY2RD8WT4cWPQmYo+//eJAwFb84kAvAc8CRcAG4Isd1n+OGIc4/vPwX/UdsA742r4+70hiZmcDs4BFQFtg9w/wfd0R/fkf5thvpIuffcQkfhERCU6kdPWIiEiQlPhFRKKMEr+ISJRR4hcRiTJK/CIiUUaJX0Qkyijxi4hEGSV+EZEo8/8BkLLD3aNZOBYAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.plot(range(epochs), history.history['val_loss'])\n",
     "plt.plot(range(epochs), history.history['loss'])"
@@ -381,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,26 +323,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n",
-      "Predicted verse: ٱٱللِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِِ\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def decode_sequence(input_seq):\n",
     "    # Encode the input as state vectors.\n",


### PR DESCRIPTION
Jupyter notebook files store data which is unnecessary for version control, such as execution count and outputs. This commit adds a filter using nbstripout to strip this data when adding a jupyter notebook file.