### PR TITLE
pyAudioAnalysis short-term feature extraction

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,5 @@ dependencies:
   - scikit-learn=0.20.2
   - tensorflow=1.12.0
   - pip:
+    - pyAudioAnalysis==0.2.5
     - webrtcvad==2.0.10


### PR DESCRIPTION
Add another output format to generate_features.py: short_term_features,
which uses stFeatureExtraction() from the pyAudioAnalysis library.
Generates 34 different features (including MFCCs) for each signal.

Details can be found on https://github.com/tyiannak/pyAudioAnalysis/wiki/3.-Feature-Extraction.