### PR TITLE
Convert invalid wav files to correct format

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - matplotlib=3.0.2
   - numpy=1.15.4
   - pandas=0.24.1
+  - pydub=0.23.1
   - python=3.6.8
   - requests=2.21.0
   - scikit-learn=0.20.2


### PR DESCRIPTION
Use pydub in download.py to convert audio files that are not in wav format (such as mpeg-4) to the correct format. Adds pydub as a dependency, and ffmpeg as a system dependency. Fixes #23.

Fix taken from https://github.com/Tarteel-io/tarteel-api/issues/165#issuecomment-462164952. 

@khanh111 if you've already done this in your updated scripts (or if this PR interferes with what you currently have), then feel free to close this.